### PR TITLE
Fix flush issues in LogToSheet

### DIFF
--- a/logToSheet.js
+++ b/logToSheet.js
@@ -13,12 +13,15 @@ class LogToSheet {
   }
 
   flush() {
+    if(this.logs.length === 0) {
+      return;
+    }
     if(this.sheet == null) {
       this.sheet = SpreadsheetApp.getActiveSpreadsheet().insertSheet(this.sheetName);
     }
     let lastRow = this.sheet.getLastRow() + 1;
+    this.sheet.insertRowsAfter(lastRow - 1, this.logs.length);
     let range = this.sheet.getRange(lastRow, 1, this.logs.length, this.logs[0].length);
-    this.sheet.insertRowsAfter(lastRow, this.logs.length);
     range.setValues(this.logs);
     this.logs = [];
   }


### PR DESCRIPTION
## Summary
- handle empty log arrays in `flush`
- avoid inserting a blank row when flushing logs

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68497594f5b88324b6950c0f9fc4e1ef