### PR TITLE
Enhance LogToSheet for production use

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,22 @@
 Lightweight in-sheet logging for Google Sheets. Intended to provide spreadsheet users with contextual information without having to navigate to Apps Script logs.
 
 ## Usage
-Initialize a new instance of LogToSheet. LogToSheet expects 1 argument, an object containing a key ```sheet```. The value of ```sheet``` is the name of the sheet where logs should be outputted. The sheet doesn't need to already exist. If it doesn't exist, the value you provide should meet Google Sheets' naming requirements.
+Initialize a new instance of `LogToSheet`. The constructor accepts an options object. At a minimum you must provide the sheet name via the `sheet` option.
+You can also optionally override the timestamp time zone with the `timeZone` option.
 ```
 const log = new LogToSheet({
-  "sheet": "Logs"
+  sheet: "Logs",
+  // optional: timezone used for timestamps
+  timeZone: "America/Los_Angeles"
 });
 ```
 Insert new logs by calling the  ```insert``` method with 1 argument which is the value to log. 
 ```
 log.insert("My first log");
 ```
-Output the logs to the sheet by calling ```flush```. Flush will attempt to create the output sheet. 
+Output the logs to the sheet by calling `flush`. `flush` will attempt to create
+the output sheet if it does not already exist. `flush` is also automatically
+invoked when more than 500 entries have been queued.
 ```
 log.flush();
 ```
@@ -21,7 +26,8 @@ LogToSheet will output 2 columns to the sheet. The first column is a date time c
 ## Example
 ```
 const log = new LogToSheet({
-    "sheet": "Logs"
+    sheet: "Logs",
+    timeZone: "America/Los_Angeles"
 });
 
 for(let i = 1; i <= 100; i++) {

--- a/logToSheet.js
+++ b/logToSheet.js
@@ -1,24 +1,50 @@
+"use strict";
+
+/**
+ * Lightweight logger that writes messages to a Google Sheet.
+ *
+ * @param {Object} options - Configuration options.
+ * @param {string} options.sheet - Target sheet name.
+ * @param {string} [options.timeZone="UTC"] - Time zone for timestamp.
+ */
 class LogToSheet {
   constructor(options) {
+    if (!options || !options.sheet) {
+      throw new Error("LogToSheet requires a 'sheet' option.");
+    }
+
     this.sheetName = options.sheet;
-    this.sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(this.sheetName);
+    this.timeZone = options.timeZone || "UTC";
+    this.spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
+    this.sheet = this.spreadsheet.getSheetByName(this.sheetName);
     this.logs = [];
+    this.maxBuffer = 500;
   }
 
+  /**
+   * Queues a message for logging.
+   * @param {*} log - The message to log.
+   */
   insert(log) {
-    if(log) {
-      let timestamp = Utilities.formatDate(new Date(), "UTC", "yyyy-MM-dd HH:mm:ss"); 
-      this.logs.push([timestamp,log]);
+    if (log == null) return;
+    var timestamp = Utilities.formatDate(new Date(), this.timeZone, "yyyy-MM-dd HH:mm:ss");
+    this.logs.push([timestamp, log]);
+    if (this.logs.length >= this.maxBuffer) {
+      this.flush();
     }
   }
 
+  /**
+   * Writes queued logs to the sheet.
+   */
   flush() {
-    if(this.sheet == null) {
-      this.sheet = SpreadsheetApp.getActiveSpreadsheet().insertSheet(this.sheetName);
+    if (this.logs.length === 0) return;
+    if (this.sheet == null) {
+      this.sheet = this.spreadsheet.insertSheet(this.sheetName);
     }
-    let lastRow = this.sheet.getLastRow() + 1;
-    let range = this.sheet.getRange(lastRow, 1, this.logs.length, this.logs[0].length);
+    var lastRow = this.sheet.getLastRow() + 1;
     this.sheet.insertRowsAfter(lastRow, this.logs.length);
+    var range = this.sheet.getRange(lastRow, 1, this.logs.length, this.logs[0].length);
     range.setValues(this.logs);
     this.logs = [];
   }


### PR DESCRIPTION
## Summary
- add runtime checks, timezone option and auto flushing to `LogToSheet`
- update examples and docs with new options

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852d28af2d48324a0607c47f0630448