### PR TITLE
Update timezone info in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ invoked when more than 500 entries have been queued.
 log.flush();
 ```
 ## Output Format
-LogToSheet will output 2 columns to the sheet. The first column is a date time corresponding to the time of the log in ```yyyy-MM-dd HH:mm:ss``` format (timezone is UTC). The second column is the log.
+LogToSheet will output 2 columns to the sheet. The first column is a date time corresponding to the time of the log in ```yyyy-MM-dd HH:mm:ss``` format using the configured `timeZone` (defaults to UTC). The second column is the log.
 ## Example
 ```
 const log = new LogToSheet({


### PR DESCRIPTION
## Summary
- clarify that timestamps use configured `timeZone` and default to UTC in Output Format section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855739a529c83249f66f75d80a234ef