### PR TITLE
Add maxBuffer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,14 @@ Lightweight in-sheet logging for Google Sheets. Intended to provide spreadsheet 
 
 ## Usage
 Initialize a new instance of `LogToSheet`. The constructor accepts an options object. At a minimum you must provide the sheet name via the `sheet` option.
-You can also optionally override the timestamp time zone with the `timeZone` option.
+You can also optionally override the timestamp time zone with the `timeZone` option or configure how many logs are buffered before they are automatically flushed with the `maxBuffer` option.
 ```
 const log = new LogToSheet({
   sheet: "Logs",
   // optional: timezone used for timestamps
-  timeZone: "America/Los_Angeles"
+  timeZone: "America/Los_Angeles",
+  // optional: maximum number of entries to buffer before flush
+  maxBuffer: 1000
 });
 ```
 Insert new logs by calling the  ```insert``` method with 1 argument which is the value to log. 
@@ -17,7 +19,7 @@ log.insert("My first log");
 ```
 Output the logs to the sheet by calling `flush`. `flush` will attempt to create
 the output sheet if it does not already exist. `flush` is also automatically
-invoked when more than 500 entries have been queued.
+invoked when more than the configured `maxBuffer` value (default 500) entries have been queued.
 ```
 log.flush();
 ```

--- a/logToSheet.js
+++ b/logToSheet.js
@@ -6,6 +6,7 @@
  * @param {Object} options - Configuration options.
  * @param {string} options.sheet - Target sheet name.
  * @param {string} [options.timeZone="UTC"] - Time zone for timestamp.
+ * @param {number} [options.maxBuffer=500] - Max logs to buffer before auto flush.
  */
 class LogToSheet {
   constructor(options) {
@@ -15,10 +16,18 @@ class LogToSheet {
 
     this.sheetName = options.sheet;
     this.timeZone = options.timeZone || "UTC";
+
+    this.maxBuffer = 500;
+    if (options.maxBuffer !== undefined) {
+      if (!Number.isInteger(options.maxBuffer) || options.maxBuffer <= 0) {
+        throw new Error("The 'maxBuffer' option must be a positive integer.");
+      }
+      this.maxBuffer = options.maxBuffer;
+    }
+
     this.spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
     this.sheet = this.spreadsheet.getSheetByName(this.sheetName);
     this.logs = [];
-    this.maxBuffer = 500;
   }
 
   /**


### PR DESCRIPTION
## Summary
- add `maxBuffer` to LogToSheet constructor
- validate that `maxBuffer` is a positive integer
- document `maxBuffer` usage in the README

## Testing
- `node -c logToSheet.js`

------
https://chatgpt.com/codex/tasks/task_e_68557560ada88324a20a86366a604a70