### PR TITLE
Fix constructor override of spreadsheet ID

### DIFF
--- a/logToSheet.js
+++ b/logToSheet.js
@@ -30,7 +30,6 @@ class LogToSheet {
       this.maxBuffer = options.maxBuffer;
     }
 
-    this.spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
     this.sheet = this.spreadsheet.getSheetByName(this.sheetName);
     this.logs = [];
   }


### PR DESCRIPTION
## Summary
- keep configured spreadsheet when `spreadsheetId` is provided
- drop leftover comment

## Testing
- `node -e "require('./logToSheet.js')"`


------
https://chatgpt.com/codex/tasks/task_e_685926a5adf083249374a20aa17c14f7