### PR TITLE
Remove deprecated insert method and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,7 @@ const log = new LogToSheet({
   maxBuffer: 1000
 });
 ```
-Insert new logs by calling the  ```insert``` method with 1 argument which is the value to log. 
-```
-log.insert("My first log");
-```
+Queue logs using the level based methods such as `info`, `warn`, or `error`.
 Output the logs to the sheet by calling `flush`. `flush` will attempt to create
 the output sheet if it does not already exist. `flush` is also automatically
 invoked when more than the configured `maxBuffer` value (default 500) entries have been queued.
@@ -28,7 +25,7 @@ invoked when more than the configured `maxBuffer` value (default 500) entries ha
 log.flush();
 ```
 ## Output Format
-LogToSheet will output 2 columns to the sheet. The first column is a date time corresponding to the time of the log in ```yyyy-MM-dd HH:mm:ss``` format using the configured `timeZone` (defaults to UTC). The second column is the log.
+LogToSheet will output 3 columns to the sheet. The first column is a date time corresponding to the time of the log in ```yyyy-MM-dd HH:mm:ss``` format using the configured `timeZone` (defaults to UTC). The second column records the log level and the third column contains the message.
 ## Example
 ```
 const log = new LogToSheet({
@@ -38,7 +35,7 @@ const log = new LogToSheet({
 });
 
 for(let i = 1; i <= 100; i++) {
-  log.insert(`Demo ${i}`);
+  log.info(`Demo ${i}`);
 }
 
 log.flush();

--- a/logToSheet.js
+++ b/logToSheet.js
@@ -35,19 +35,6 @@ class LogToSheet {
   }
 
   /**
-   * Queues a message for logging.
-   * @param {*} log - The message to log.
-   */
-  insert(log) {
-    if (log == null) return;
-    var timestamp = Utilities.formatDate(new Date(), this.timeZone, "yyyy-MM-dd HH:mm:ss");
-    this.logs.push([timestamp, log]);
-    if (this.logs.length >= this.maxBuffer) {
-      this.flush();
-    }
-  }
-
-  /**
    * Writes queued logs to the sheet.
    */
   flush() {


### PR DESCRIPTION
## Summary
- remove deprecated `insert` method from `logToSheet.js`
- update README to demonstrate level-based logging instead of using `insert`

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_687b5f37059c8324bc47b0b8e80fdb69